### PR TITLE
Fix Netlify function routing path for API endpoints

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
   force = true
   from = "/api/*"
   status = 200
-  to = "/.netlify/functions/api/:splat"
+  to = "/.netlify/functions/api/api/:splat"
 
 # SPA fallback for client-side routing
 [[redirects]]


### PR DESCRIPTION
## Purpose
The user reported that no content was showing on the website when deployed from Netlify. This fix addresses the deployment issue by correcting the API function routing configuration to ensure proper content delivery.

## Code changes
- Updated the Netlify redirect rule in `netlify.toml` to fix the API function path
- Changed the redirect destination from `/.netlify/functions/api/:splat` to `/.netlify/functions/api/api/:splat`
- This ensures API requests are properly routed to the correct function endpoint during deploymentTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5f7bcd3bf2964efa9d3ee033c0948d8e/echo-garden)

👀 [Preview Link](https://5f7bcd3bf2964efa9d3ee033c0948d8e-echo-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5f7bcd3bf2964efa9d3ee033c0948d8e</projectId>-->
<!--<branchName>echo-garden</branchName>-->